### PR TITLE
Fix inline language with Safari

### DIFF
--- a/css/epfl.css
+++ b/css/epfl.css
@@ -576,10 +576,10 @@ to be removed when jahia automaticvally includes plancours.css
 #breadcrumbs .last {color:black; font-weight:bold;}
 
 #languages { float:right; background:none; }
-#languages li { background:none; display:inline; padding:0 0 0 20px;  position: relative; }
+#languages li { background:none; display:inline-block; padding:0 0 0 20px;  position: relative; }
 #languages li:before {
     content:'\00A0'; width: 11px; height: 11px;
-    position:absolute; left:3px; bottom: 0;
+    position:absolute; left:3px; top: 5px;
     background: url(../img/slash.png) no-repeat;
     
 }


### PR DESCRIPTION
**Overview**

The link to change language is absent at the top right of the window

**Environnement**

Safari

**Screenshots**

Before    |  After
:--------:|:--------------------------------------:
![before](https://cloud.githubusercontent.com/assets/2843501/26092248/38232de4-3a10-11e7-8910-1e4d06f28a74.png)|![after](https://cloud.githubusercontent.com/assets/2843501/26092253/3ca0c21e-3a10-11e7-8836-f5c2b65897ba.png)

It must remain the same for other browsers